### PR TITLE
added this._tether to correctly position element on show()

### DIFF
--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -380,6 +380,14 @@ export default EmberTetherComponent.extend({
   }),
 
   show() {
+    // this.positionTether() fixes the issues raised in
+    // https://github.com/sir-dunxalot/ember-tooltips/issues/75
+    // this.positionTether();
+
+    // we need to call this private API until we upgrade to ember-tether 0.3.1
+    if (this._tether) {
+      this._tether.position();
+    }
 
     if (this.get('isDestroying')) {
       return;

--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -383,7 +383,6 @@ export default EmberTetherComponent.extend({
     // this.positionTether() fixes the issues raised in
     // https://github.com/sir-dunxalot/ember-tooltips/issues/75
     // this.positionTether();
-
     // we need to call this private API until we upgrade to ember-tether 0.3.1
     if (this._tether) {
       this._tether.position();


### PR DESCRIPTION
There is a known bug within ember-tooltips (https://github.com/sir-dunxalot/ember-tooltips/issues/75) that causes the tooltip to be incorrectly positioned in some circumstances. This bug has been seen within some wizard pages and ember tables. This bug was reported by @Chenxing-Zenefits and is currently blocking the full release of ember-tooltips.

This fix mirrors that found in https://github.com/sir-dunxalot/ember-tooltips/pull/83 and adds an approach that works with Zenefits' `ember-tether0.1.2` version

BEFORE
![before](https://cloud.githubusercontent.com/assets/8782940/16813055/d2a347aa-48e4-11e6-800f-b136a33b4903.gif)


AFTER
![after](https://cloud.githubusercontent.com/assets/8782940/16813058/d6bc4c10-48e4-11e6-82a0-796f073093ff.gif)
