### PR TITLE
add check for destroyed obj

### DIFF
--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -367,7 +367,7 @@ export default EmberTetherComponent.extend({
       }
 
       const _showTimer = run.later(this, () => {
-        if (!this.get('destroying')) {
+        if (!this.get('destroying') || !this.get('isDestroyed')) {
           this.set('isShown', true);
         }
       }, delay);


### PR DESCRIPTION
This fixes an error that occurs when the user may be hovering over a target and a condition changes, such that the popover should no longer be shown (in our use case, we have a button in the popover target that could lead to this condition when clicked).  When this happens, if a `delay` is set on the popover, by the time the popover is being set to be shown, the popover has already been destroyed and we get an `Uncaught Error: Assertion Failed: calling set on destroyed object`