### PR TITLE
As/start tether stop tether

### DIFF
--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -346,7 +346,6 @@ export default EmberTetherComponent.extend({
   }),
 
   show() {
-    this.startTether();
     // this.positionTether() fixes the issues raised in
     // https://github.com/sir-dunxalot/ember-tooltips/issues/75
     this.positionTether();
@@ -380,13 +379,14 @@ export default EmberTetherComponent.extend({
         if (!this.get('destroying')) {
           this.set('isShown', true);
         }
+        this.startTether();
       }, delay);
 
       this.set('_showTimer', _showTimer);
     } else {
 
       /* If there is no delay, show the tooltop immediately */
-
+      this.startTether();
       this.set('isShown', true);
     }
 

--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -64,7 +64,7 @@ export default EmberTetherComponent.extend({
 
   /* Properties */
 
-  attributeBindings: ['aria-hidden', 'role', 'tabindex'],
+  attributeBindings: ['aria-hidden', 'role', 'tabindex', 'is-tether-enabled'],
   classNameBindings: ['effectClass'],
   classPrefix: 'ember-tooltip-or-popover',
   classNames: ['ember-tooltip-or-popover'],
@@ -396,12 +396,17 @@ export default EmberTetherComponent.extend({
   stopTether() {
     run.schedule('afterRender', () => {
       this.get('_tether').disable();
+      this.set('is-tether-enabled', 'false');
     });
   },
 
   startTether() {
     this.get('_tether').enable();
+    this.set('is-tether-enabled', 'true');
   },
+
+  // cannot use computed.alias('_tether.enabled') for some reason
+  'is-tether-enabled': 'false',
 
   toggle() {
 

--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -220,6 +220,8 @@ export default EmberTetherComponent.extend({
 
     this.set('isShown', false);
     this.sendAction('onHide', this);
+
+    this.stopTether();
   },
 
   didInsertElement() {
@@ -278,6 +280,10 @@ export default EmberTetherComponent.extend({
     }
 
     this.set('offset', offset);
+
+    if (event !== 'none' || !this.get('isShown')) {
+      this.stopTether();
+    }
   },
 
   /*
@@ -318,6 +324,7 @@ export default EmberTetherComponent.extend({
     const isShown = this.get('isShown');
 
     if (isShown) {
+      this.startTether();
       const duration = cleanNumber(this.get('duration'));
 
       run.cancel(this.get('_hideTimer'));
@@ -333,10 +340,13 @@ export default EmberTetherComponent.extend({
 
         this.set('_hideTimer', hideTimer);
       }
+    } else {
+      this.stopTether();
     }
   }),
 
   show() {
+    this.startTether();
     // this.positionTether() fixes the issues raised in
     // https://github.com/sir-dunxalot/ember-tooltips/issues/75
     this.positionTether();
@@ -381,6 +391,16 @@ export default EmberTetherComponent.extend({
     }
 
     this.sendAction('onShow', this);
+  },
+
+  stopTether() {
+    run.schedule('afterRender', () => {
+      this.get('_tether').disable();
+    });
+  },
+
+  startTether() {
+    this.get('_tether').enable();
   },
 
   toggle() {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -22,7 +22,7 @@
   class='logo-tooltip'
   event='none'
   target='#ember-logo'
-  tooltipIsVisible=showLogoTooltip
+  isShown=showLogoTooltip
   side='right'
   spacing=15
 }}

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -12,7 +12,7 @@ export function assertHide(assert, context) {
   const $tooltip = context.$().find('.ember-tooltip');
   assert.equal($tooltip.attr('aria-hidden'), 'true', 'Should hide tooltip');
   assert.equal($tooltip.attr('is-tether-enabled'), 'false',
-    'tether should NOT be enabled if tooltip is visible');
+    'tether should NOT be enabled if tooltip is hidden');
 
 }
 

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -1,14 +1,18 @@
 export function assertShow(assert, context) {
 
-  assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'false',
-    'Should show tooltip');
+	const $tooltip = context.$().find('.ember-tooltip');
+  assert.equal($tooltip.attr('aria-hidden'), 'false', 'Should show tooltip');
+  assert.equal($tooltip.attr('is-tether-enabled'), 'true',
+  	'tether should be enabled if tooltip is visible');
 
 }
 
 export function assertHide(assert, context) {
 
-  assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'true',
-    'Should hide tooltip');
+  const $tooltip = context.$().find('.ember-tooltip');
+  assert.equal($tooltip.attr('aria-hidden'), 'true', 'Should hide tooltip');
+  assert.equal($tooltip.attr('is-tether-enabled'), 'false',
+    'tether should NOT be enabled if tooltip is visible');
 
 }
 

--- a/tests/integration/components/delay-test.js
+++ b/tests/integration/components/delay-test.js
@@ -12,7 +12,7 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | delay', {
 test('It animates with delay passed as a number', function(assert) {
   const done = assert.async();
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-component delay=300}}`);
 
@@ -49,7 +49,7 @@ test('It animates with delay passed as a number', function(assert) {
 test('It animates with delay passed as a string', function(assert) {
   const done = assert.async();
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-component delay='300'}}`);
 

--- a/tests/integration/components/duration-test.js
+++ b/tests/integration/components/duration-test.js
@@ -12,7 +12,7 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | duration', {
 test('It hides after the given duration', function(assert) {
   const done = assert.async();
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component duration=300}}`);
 
@@ -35,7 +35,7 @@ test('It hides after the given duration', function(assert) {
 
 test('It hides before the given duration, if requested', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component duration=300}}`);
 
@@ -58,7 +58,7 @@ test('It hides before the given duration, if requested', function(assert) {
 test('It uses duration after the first show', function(assert) {
   const done = assert.async();
 
-  assert.expect(5);
+  assert.expect(10);
 
   this.render(hbs`{{tooltip-on-component duration=300}}`);
 

--- a/tests/integration/components/event-test.js
+++ b/tests/integration/components/event-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | event', {
 
 test('It toggles with hover', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component}}`);
 
@@ -33,7 +33,7 @@ test('It toggles with hover', function(assert) {
 
 test('It toggles with click', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component event='click'}}`);
 
@@ -55,7 +55,7 @@ test('It toggles with click', function(assert) {
 
 test('It toggles with focus', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`
     <div id="target">
@@ -83,7 +83,7 @@ test('It toggles with focus', function(assert) {
 
 test('It does not show with none', function(assert) {
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-component event='none'}}`);
 

--- a/tests/integration/components/hide-on-test.js
+++ b/tests/integration/components/hide-on-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | hideOn', {
 
 test('It hides with hideOn', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component hideOn='click'}}`);
 

--- a/tests/integration/components/show-on-test.js
+++ b/tests/integration/components/show-on-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | showOn', {
 
 test('It shows with showOn', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-component showOn='click'}}`);
 

--- a/tests/integration/components/tooltip-is-visible-test.js
+++ b/tests/integration/components/tooltip-is-visible-test.js
@@ -11,18 +11,18 @@ moduleForComponent('tooltip-on-component', 'Integration | Option | isShown', {
 
 test('It toggles with isShown', function(assert) {
 
-  assert.expect(2);
+  assert.expect(4);
 
-  this.set('showTooltip', true);
+  this.set('showTooltip', false);
 
   this.render(hbs`{{tooltip-on-component isShown=showTooltip}}`);
 
-  assertShow(assert, this);
+  assertHide(assert, this);
 
   run(() => {
-    this.set('showTooltip', false);
+    this.set('showTooltip', true);
   });
 
-  assertHide(assert, this);
+  assertShow(assert, this);
 
 });


### PR DESCRIPTION
disable tethering while tooltips are hidden (https://github.com/sir-dunxalot/ember-tooltips/pull/96)

We have also added tests to ensure that the `is-tether-enabled` property aligns with the `isShown` property.

### Before
![reposition-before](https://cloud.githubusercontent.com/assets/8782940/19059373/3607b020-8994-11e6-81de-a1e91b8049c7.gif)


### After (it repositions if the tooltip is shown; aka when aria-hidden="false")
![reposition-after](https://cloud.githubusercontent.com/assets/8782940/19059372/2ee1be4e-8994-11e6-853d-abe4fa896a24.gif)

