### PR TITLE
As/start tether fix

### DIFF
--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -281,10 +281,10 @@ export default EmberTetherComponent.extend({
 
     this.set('offset', offset);
 
-    if (!this.get('isShown')) {
-      this.stopTether();
-    } else {
+    if (this.get('isShown')) {
       this.startTether();
+    } else {
+      this.stopTether();
     }
   },
 

--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -281,8 +281,10 @@ export default EmberTetherComponent.extend({
 
     this.set('offset', offset);
 
-    if (event !== 'none' || !this.get('isShown')) {
+    if (!this.get('isShown')) {
       this.stopTether();
+    } else {
+      this.startTether();
     }
   },
 
@@ -396,13 +398,13 @@ export default EmberTetherComponent.extend({
   stopTether() {
     run.schedule('afterRender', () => {
       this.get('_tether').disable();
-      this.set('is-tether-enabled', 'false');
+      this.set('is-tether-enabled', 'false'); // used for integration tests
     });
   },
 
   startTether() {
     this.get('_tether').enable();
-    this.set('is-tether-enabled', 'true');
+    this.set('is-tether-enabled', 'true'); // used for integration tests
   },
 
   // cannot use computed.alias('_tether.enabled') for some reason

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -1,9 +1,9 @@
 export function assertShow(assert, context) {
 
-	const $tooltip = context.$().find('.ember-tooltip');
+  const $tooltip = context.$().find('.ember-tooltip');
   assert.equal($tooltip.attr('aria-hidden'), 'false', 'Should show tooltip');
   assert.equal($tooltip.attr('is-tether-enabled'), 'true',
-  	'tether should be enabled if tooltip is visible');
+    'tether should be enabled if tooltip is visible');
 
 }
 

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -19,14 +19,20 @@ export function assertHide(assert, context) {
 
 export function assertPopoverShow(assert, context) {
 
-  assert.equal(context.$().find('.ember-popover').attr('aria-hidden'), 'false',
+  const $popover = context.$().find('.ember-popover');
+  assert.equal($popover.attr('aria-hidden'), 'false',
     'Should show popover');
+  assert.equal($popover.attr('is-tether-enabled'), 'true',
+    'tether should be enabled if popover is visible');
 
 }
 
 export function assertPopoverHide(assert, context) {
 
-  assert.equal(context.$().find('.ember-popover').attr('aria-hidden'), 'true',
+  const $popover = context.$().find('.ember-popover');
+  assert.equal($popover.attr('aria-hidden'), 'true',
     'Should hide popover');
+  assert.equal($popover.attr('is-tether-enabled'), 'false',
+    'tether should NOT be enabled if popover is hidden');
 
 }

--- a/tests/integration/components/popover/api-test.js
+++ b/tests/integration/components/popover/api-test.js
@@ -35,7 +35,7 @@ test('Popover: click target, click hideAction', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -72,7 +72,7 @@ test('Popover: click target, click hideAction, click target', function(assert) {
 
   assertPopoverShow(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -116,6 +116,6 @@ test('Popover: click target, click popover, click hideAction, click target', fun
 
   assertPopoverShow(assert, this);
 
-  assert.expect(5);
+  assert.expect(10);
 
 });

--- a/tests/integration/components/popover/click-test.js
+++ b/tests/integration/components/popover/click-test.js
@@ -31,7 +31,7 @@ test('Popover: click target, click target', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -64,7 +64,7 @@ test('Popover: click target, click popover, click target', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -96,7 +96,7 @@ test('Popover: click target, click elsewhere', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -135,6 +135,6 @@ test('Popover: click target, click popover, click elsewhere', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });

--- a/tests/integration/components/popover/focus-test.js
+++ b/tests/integration/components/popover/focus-test.js
@@ -44,7 +44,7 @@ test('Popover: target focus, popover focus, popover blur', function(assert) {
 		done();
 	}, 10);
 
-	assert.expect(4);
+	assert.expect(8);
 
 });
 
@@ -92,7 +92,7 @@ test('Popover: target focus, targetInterior focus, popover focus, popover blur',
 		done();
 	}, 10);
 
-	assert.expect(5);
+	assert.expect(10);
 
 });
 
@@ -140,6 +140,6 @@ test('Popover: target focus, popover focus, popoverInterior focus, popover blur'
 		done();
 	}, 100);
 
-	assert.expect(5);
+	assert.expect(10);
 
 });

--- a/tests/integration/components/popover/hover-test.js
+++ b/tests/integration/components/popover/hover-test.js
@@ -35,7 +35,7 @@ test('Popover: hover target, hover elsewhere', function(assert) {
     done();
   }, 300);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -69,7 +69,7 @@ test('Popover: hover target, hover popover (too slow)', function(assert) {
     done();
   }, 500);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -130,6 +130,6 @@ test('Popover: hover target, hover inbetween, hover popover, hover elsewhere', f
     done();
   }, 1000);
 
-  assert.expect(6);
+  assert.expect(12);
 
 });

--- a/tests/integration/components/popover/none-test.js
+++ b/tests/integration/components/popover/none-test.js
@@ -42,6 +42,6 @@ test('Popover: never shows with none', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });

--- a/tests/integration/components/tooltip-is-visible-test.js
+++ b/tests/integration/components/tooltip-is-visible-test.js
@@ -13,16 +13,16 @@ test('It toggles with isShown', function(assert) {
 
   assert.expect(4);
 
-  this.set('showTooltip', false);
+  this.set('showTooltip', true);
 
   this.render(hbs`{{tooltip-on-component isShown=showTooltip}}`);
 
-  assertHide(assert, this);
+  assertShow(assert, this);
 
   run(() => {
-    this.set('showTooltip', true);
+    this.set('showTooltip', false);
   });
 
-  assertShow(assert, this);
+  assertHide(assert, this);
 
 });


### PR DESCRIPTION
* reverts a test hack introduced in a prior PR https://github.com/zenefits/ember-tooltips/pull/21/files

* adds the same `is-tether-enabled` tests for popovers

* start or stop tethering based on the component's initial `isShown` state https://github.com/zenefits/ember-tooltips/pull/24/files#diff-eafc17148ee89489b3d8098122b506e6R284